### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -28,6 +28,6 @@
     ],
     "sharedGlobals": []
   },
-  "nxCloudAccessToken": "MDc4OTRmZGUtOWFiMy00ZDYxLTgyOGYtZDk0YzU1ODQyOGVlfHJlYWQtd3JpdGU=",
+  "nxCloudAccessToken": "OGEyZWU3MGItODE5NC00NzYyLTgzZDctZDkwNzA1NDYzMzE3fHJlYWQtd3JpdGU=",
   "nxCloudUrl": "http://localhost:4202"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/664acee2baf78dabdcc189b0/workspaces/664c26feb61554326c20a85b

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.